### PR TITLE
[partial][common] log

### DIFF
--- a/.ayi.example.yml
+++ b/.ayi.example.yml
@@ -3,7 +3,7 @@ debug: true
 test:
     - sh -c "go test -v -cover $(glide novendor)"
 install:
-    - go install   
+    - go install
 update:
     - glide update    
 user: example-user

--- a/app/git/config.go
+++ b/app/git/config.go
@@ -40,7 +40,6 @@ var hosts []Host
 
 // host map is more convenient
 var hostsMap map[string]Host
-var log = util.Logger
 
 // ReadConfigFile read user defined hosts in .ayi.yml
 func ReadConfigFile() {

--- a/app/git/pkg.go
+++ b/app/git/pkg.go
@@ -1,0 +1,7 @@
+package git
+
+import (
+	"github.com/dyweb/Ayi/util"
+)
+
+var log = util.Logger.NewEntryWithPkg("a.a.git")

--- a/app/web/pkg.go
+++ b/app/web/pkg.go
@@ -1,0 +1,7 @@
+package web
+
+import (
+	"github.com/dyweb/Ayi/util"
+)
+
+var log = util.Logger.NewEntryWithPkg("a.a.web")

--- a/app/web/server.go
+++ b/app/web/server.go
@@ -5,11 +5,8 @@ import (
 	"net/http"
 
 	"github.com/GeertJohan/go.rice"
-	"github.com/dyweb/Ayi/util"
 	"github.com/gocraft/web"
 )
-
-var log = util.Logger
 
 type Server struct {
 	Root   string

--- a/cmd/pkg.go
+++ b/cmd/pkg.go
@@ -1,0 +1,7 @@
+package cmd
+
+import (
+	"github.com/dyweb/Ayi/util"
+)
+
+var log = util.Logger.NewEntryWithPkg("a.cmd")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,9 +22,6 @@ var (
 	dryRun  bool
 )
 
-// local shortcut shared among the whole cmd package, only needs to define in one file
-var log = util.Logger
-
 // RootCmd represents the base command when called without any subcommands
 var RootCmd = &cobra.Command{
 	Use:   "Ayi",

--- a/common/README.md
+++ b/common/README.md
@@ -1,0 +1,28 @@
+# Common util
+
+Common utils that could be used outside Ayi
+
+- log
+- command runner
+- web server
+- http client 
+- resource binding (replace go.rice) 
+
+## Log
+
+- filter log by fields
+
+## Command runner
+
+- dry run
+- run in background (like foreman)
+- error handling
+
+## Web server
+
+- static file server (`Ayi web static`)
+
+## Http client
+
+- like python's requests `client.Get('http://api.github.com/').JSON()`
+

--- a/common/log/README.md
+++ b/common/log/README.md
@@ -1,0 +1,7 @@
+# Log that support filter by field
+
+- [ ] thread safe
+- [ ] log to stdout
+- [ ] leveled logging 
+- [ ] support filed
+- [ ] filter by field

--- a/common/log/README.md
+++ b/common/log/README.md
@@ -1,7 +1,39 @@
 # Log that support filter by field
 
-- [ ] thread safe
-- [ ] log to stdout
-- [ ] leveled logging 
-- [ ] support filed
-- [ ] filter by field
+This a simple re-implementation of [logrus](https://github.com/sirupsen/logrus)
+
+## Added
+
+- `Filter` and `PkgFilter`
+- `TraceLevel`
+
+## Fixed
+
+- Remove duplicate code in `Logger` and `Entry` by only allow using `Entry` to log
+- Use elasped time in `TextFormatter`, see [issue](https://github.com/sirupsen/logrus/issues/457)
+- `FatalLevel` should be more severe than `PanicLevel`
+
+## Removed 
+
+- lock on logger when call log for `Entry`
+- Support for blocking Hook
+- Trim `\n` when using `*f`
+
+## TODO
+
+- [ ] read filters from command line or config files
+- [ ] `WithFields`
+- [ ] pool for `Entry` and `bytes.Writer`
+- [ ] JSON Formatter
+- [ ] Multiple output
+- [ ] async Hook
+- [ ] Batch write and flush like [zap](https://github.com/uber-go/zap)
+- [ ] Shutdown handler
+
+## DONE
+
+- thread safe by not using pointer receiver https://github.com/at15/go-learning/issues/3
+- log to stdout, implemented `TextFormatter`
+- leveled logging, add `Trace` level
+- support field
+- filter by field

--- a/common/log/doc.go
+++ b/common/log/doc.go
@@ -2,3 +2,5 @@
 Package log can filter log by field and support multiple level
 */
 package log
+
+// TODO: https://github.com/fluhus/godoc-tricks

--- a/common/log/doc.go
+++ b/common/log/doc.go
@@ -1,0 +1,4 @@
+/*
+Package log can filter log by field and support multiple level
+*/
+package log

--- a/common/log/entry.go
+++ b/common/log/entry.go
@@ -1,0 +1,5 @@
+package log
+
+type Entry struct {
+	Fields Fields
+}

--- a/common/log/entry.go
+++ b/common/log/entry.go
@@ -81,7 +81,7 @@ func (entry *Entry) Error(args ...interface{}) {
 	}
 }
 
-func (entry *Entry) Painc(args ...interface{}) {
+func (entry *Entry) Panic(args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
 		entry.log(PanicLevel, fmt.Sprint(args...))
 	}
@@ -129,7 +129,7 @@ func (entry *Entry) Errorf(format string, args ...interface{}) {
 	}
 }
 
-func (entry *Entry) Paincf(format string, args ...interface{}) {
+func (entry *Entry) Panicf(format string, args ...interface{}) {
 	if entry.Logger.Level >= PanicLevel {
 		entry.log(PanicLevel, fmt.Sprintf(format, args...))
 	}

--- a/common/log/entry.go
+++ b/common/log/entry.go
@@ -81,20 +81,19 @@ func (entry *Entry) Error(args ...interface{}) {
 	}
 }
 
+func (entry *Entry) Painc(args ...interface{}) {
+	if entry.Logger.Level >= PanicLevel {
+		entry.log(PanicLevel, fmt.Sprint(args...))
+	}
+	panic(fmt.Sprint(args...))
+}
+
 func (entry *Entry) Fatal(args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.log(PanicLevel, fmt.Sprint(args...))
 	}
 	// TODO: allow register handlers like logrus
 	os.Exit(1)
-}
-
-// TODO: maybe Painc should comes after fatal
-func (entry *Entry) Painc(args ...interface{}) {
-	if entry.Logger.Level >= PanicLevel {
-		entry.log(PanicLevel, fmt.Sprint(args...))
-	}
-	panic(fmt.Sprint(args...))
 }
 
 // Printf functions
@@ -130,18 +129,17 @@ func (entry *Entry) Errorf(format string, args ...interface{}) {
 	}
 }
 
+func (entry *Entry) Paincf(format string, args ...interface{}) {
+	if entry.Logger.Level >= PanicLevel {
+		entry.log(PanicLevel, fmt.Sprintf(format, args...))
+	}
+	panic(fmt.Sprint(args...))
+}
+
 func (entry *Entry) Fatalf(format string, args ...interface{}) {
 	if entry.Logger.Level >= FatalLevel {
 		entry.log(PanicLevel, fmt.Sprintf(format, args...))
 	}
 	// TODO: allow register handlers like logrus
 	os.Exit(1)
-}
-
-// TODO: maybe Painc should comes after fatal
-func (entry *Entry) Paincf(format string, args ...interface{}) {
-	if entry.Logger.Level >= PanicLevel {
-		entry.log(PanicLevel, fmt.Sprintf(format, args...))
-	}
-	panic(fmt.Sprint(args...))
 }

--- a/common/log/entry.go
+++ b/common/log/entry.go
@@ -6,6 +6,7 @@ import (
 	"time"
 )
 
+// Entry is the real logger
 type Entry struct {
 	Logger  *Logger
 	Fields  Fields
@@ -14,10 +15,12 @@ type Entry struct {
 	Message string
 }
 
+// AddField adds tag to entry
 func (entry *Entry) AddField(key string, value string) {
 	entry.Fields[key] = value
 }
 
+// AddFields adds multiple tags to entry
 func (entry *Entry) AddFields(fields Fields) {
 	for k, v := range fields {
 		entry.Fields[k] = v

--- a/common/log/entry.go
+++ b/common/log/entry.go
@@ -1,5 +1,52 @@
 package log
 
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
 type Entry struct {
-	Fields Fields
+	Logger  *Logger
+	Fields  Fields
+	Time    time.Time
+	Level   Level
+	Message string
+}
+
+func (entry *Entry) AddField(key string, value string) {
+	entry.Fields[key] = value
+}
+
+func (entry *Entry) AddFields(fields Fields) {
+	for k, v := range fields {
+		entry.Fields[k] = v
+	}
+}
+
+// This function is not defined with a pointer receiver because we change
+// the attribute of struct without using lock, if we use pointer, it would
+// become race condition for multiple goroutines.
+// see https://github.com/at15/go-learning/issues/3
+func (entry Entry) log(level Level, msg string) bool {
+	entry.Time = time.Now()
+	entry.Level = level
+	entry.Message = msg
+	// don't log if it can't pass the filter
+	for _, filter := range entry.Logger.Filters[level] {
+		if !filter.Filter(&entry) {
+			return false
+		}
+	}
+	serialized, err := entry.Logger.Formatter.Format(&entry)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to serialize, %v\n", err)
+		return false
+	}
+	_, err = entry.Logger.Out.Write(serialized)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to write, %v\n", err)
+		return false
+	}
+	return true
 }

--- a/common/log/entry.go
+++ b/common/log/entry.go
@@ -50,3 +50,98 @@ func (entry Entry) log(level Level, msg string) bool {
 	}
 	return true
 }
+
+func (entry *Entry) Trace(args ...interface{}) {
+	if entry.Logger.Level >= TraceLevel {
+		entry.log(TraceLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Debug(args ...interface{}) {
+	if entry.Logger.Level >= DebugLevel {
+		entry.log(DebugLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Info(args ...interface{}) {
+	if entry.Logger.Level >= InfoLevel {
+		entry.log(InfoLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Warn(args ...interface{}) {
+	if entry.Logger.Level >= WarnLevel {
+		entry.log(WarnLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Error(args ...interface{}) {
+	if entry.Logger.Level >= ErrorLevel {
+		entry.log(ErrorLevel, fmt.Sprint(args...))
+	}
+}
+
+func (entry *Entry) Fatal(args ...interface{}) {
+	if entry.Logger.Level >= FatalLevel {
+		entry.log(PanicLevel, fmt.Sprint(args...))
+	}
+	// TODO: allow register handlers like logrus
+	os.Exit(1)
+}
+
+// TODO: maybe Painc should comes after fatal
+func (entry *Entry) Painc(args ...interface{}) {
+	if entry.Logger.Level >= PanicLevel {
+		entry.log(PanicLevel, fmt.Sprint(args...))
+	}
+	panic(fmt.Sprint(args...))
+}
+
+// Printf functions
+// NOTE: the *f functions does NOT call * functions like logrus does, it just copy and paste
+
+func (entry *Entry) Tracef(format string, args ...interface{}) {
+	if entry.Logger.Level >= TraceLevel {
+		entry.log(TraceLevel, fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Debugf(format string, args ...interface{}) {
+	if entry.Logger.Level >= DebugLevel {
+		entry.log(DebugLevel, fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Infof(format string, args ...interface{}) {
+	if entry.Logger.Level >= InfoLevel {
+		entry.log(InfoLevel, fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Warnf(format string, args ...interface{}) {
+	if entry.Logger.Level >= WarnLevel {
+		entry.log(WarnLevel, fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Errorf(format string, args ...interface{}) {
+	if entry.Logger.Level >= ErrorLevel {
+		entry.log(ErrorLevel, fmt.Sprintf(format, args...))
+	}
+}
+
+func (entry *Entry) Fatalf(format string, args ...interface{}) {
+	if entry.Logger.Level >= FatalLevel {
+		entry.log(PanicLevel, fmt.Sprintf(format, args...))
+	}
+	// TODO: allow register handlers like logrus
+	os.Exit(1)
+}
+
+// TODO: maybe Painc should comes after fatal
+func (entry *Entry) Paincf(format string, args ...interface{}) {
+	if entry.Logger.Level >= PanicLevel {
+		entry.log(PanicLevel, fmt.Sprintf(format, args...))
+	}
+	panic(fmt.Sprint(args...))
+}

--- a/common/log/entry_test.go
+++ b/common/log/entry_test.go
@@ -1,0 +1,9 @@
+package log
+
+import "testing"
+
+func TestEntrylog(t *testing.T) {
+	logger := NewLogger()
+	entry := logger.NewEntry()
+	entry.log(DebugLevel, "hahaha")
+}

--- a/common/log/entry_test.go
+++ b/common/log/entry_test.go
@@ -8,5 +8,36 @@ func TestEntrylog(t *testing.T) {
 	entry.AddField("pkg", "dummy.d")
 	entry.AddField("name", "jack")
 	entry.log(DebugLevel, "hahaha")
+
+}
+
+func TestEntryLevelLog(t *testing.T){
+	logger := NewLogger()
+	f := NewTextFormatter()
+	f.EnableColor = true
+	logger.Formatter = f
+	entry := logger.NewEntry()
+	// NOTE: when run it in IDEA, the terminal does not have color, run it in real terminal it will show
+	entry.Debug("You should not see me!")
 	entry.Infof("%s %d", "haha", 1)
+	entry.Warnf("%s %d", "haha", 1)
+	entry.Errorf("%s %d", "haha", 1)
+
+	logger2 := NewLogger()
+	f2 := NewTextFormatter()
+	f2.EnableColor = true
+	f2.EnableElapsedTime = false
+	logger2.Formatter = f2
+	entry2 := logger2.NewEntry()
+	entry2.Info("I should have full timestamp")
+
+	logger3 := NewLogger()
+	logger3.Level = DebugLevel
+	f3 := NewTextFormatter()
+	f3.EnableColor = false
+	f3.EnableTimeStamp = false
+	logger3.Formatter = f3
+	entry3 := logger3.NewEntry()
+	entry3.Info("I should have no timestamp")
+	entry3.Debug("You should see me!")
 }

--- a/common/log/entry_test.go
+++ b/common/log/entry_test.go
@@ -5,5 +5,8 @@ import "testing"
 func TestEntrylog(t *testing.T) {
 	logger := NewLogger()
 	entry := logger.NewEntry()
+	entry.AddField("pkg", "dummy.d")
+	entry.AddField("name", "jack")
 	entry.log(DebugLevel, "hahaha")
+	entry.Infof("%s %d", "haha", 1)
 }

--- a/common/log/entry_test.go
+++ b/common/log/entry_test.go
@@ -2,7 +2,7 @@ package log
 
 import "testing"
 
-func TestEntrylog(t *testing.T) {
+func TestEntry_log(t *testing.T) {
 	logger := NewLogger()
 	entry := logger.NewEntry()
 	entry.AddField("pkg", "dummy.d")
@@ -11,7 +11,7 @@ func TestEntrylog(t *testing.T) {
 
 }
 
-func TestEntryLevelLog(t *testing.T){
+func TestEntry_LeveledLog(t *testing.T){
 	logger := NewLogger()
 	f := NewTextFormatter()
 	f.EnableColor = true

--- a/common/log/filter.go
+++ b/common/log/filter.go
@@ -5,6 +5,7 @@ type Set map[string]bool
 // Filter determines if the entry should be logged
 type Filter interface {
 	Filter(entry *Entry) bool
+	Name() string
 }
 
 // PkgFilter only allows entry without `pkg` field or `pkg` value in the allow set to pass
@@ -20,6 +21,10 @@ func (filter *PkgFilter) Filter(entry *Entry) bool {
 	}
 	_, ok = filter.allow[pkg]
 	return ok
+}
+
+func (filter *PkgFilter) Name() string {
+	return "PkgFilter"
 }
 
 func NewPkgFilter(allow Set) *PkgFilter {

--- a/common/log/filter.go
+++ b/common/log/filter.go
@@ -1,0 +1,29 @@
+package log
+
+type Set map[string]bool
+
+// Filter determines if the entry should be logged
+type Filter interface {
+	Filter(entry *Entry) bool
+}
+
+// PkgFilter only allows entry without `pkg` field or `pkg` value in the allow set to pass
+type PkgFilter struct {
+	allow Set
+}
+
+func (filter *PkgFilter) Filter(entry *Entry) bool {
+	pkg, ok := entry.Fields["pkg"]
+	// entry without pkg is not filtered
+	if !ok {
+		return true
+	}
+	_, ok = filter.allow[pkg]
+	return ok
+}
+
+func NewPkgFilter(allow Set) *PkgFilter {
+	return &PkgFilter{
+		allow: allow,
+	}
+}

--- a/common/log/filter.go
+++ b/common/log/filter.go
@@ -19,6 +19,7 @@ func (filter *PkgFilter) Filter(entry *Entry) bool {
 	if !ok {
 		return true
 	}
+	// TODO: may store bool to enable disallow using just one map.
 	_, ok = filter.allow[pkg]
 	return ok
 }

--- a/common/log/filter_test.go
+++ b/common/log/filter_test.go
@@ -11,7 +11,7 @@ func TestFilterInterface(t *testing.T) {
 	var _ Filter = (*PkgFilter)(nil)
 }
 
-func TestPkgFilter(t *testing.T) {
+func TestPkgFilter_Filter(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 

--- a/common/log/filter_test.go
+++ b/common/log/filter_test.go
@@ -7,6 +7,12 @@ import (
 )
 
 func TestFilterInterface(t *testing.T) {
+	t.Parallel()
+	var _ Filter = (*PkgFilter)(nil)
+}
+
+func TestPkgFilter(t *testing.T) {
+	t.Parallel()
 	assert := assert.New(t)
 
 	allow := make(map[string]bool)

--- a/common/log/filter_test.go
+++ b/common/log/filter_test.go
@@ -1,0 +1,25 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFilterInterface(t *testing.T) {
+	assert := assert.New(t)
+
+	allow := make(map[string]bool)
+	allow["ayi.app.git"] = true
+	f := NewPkgFilter(allow)
+	entryWithoutField := &Entry{}
+	assert.True(f.Filter(entryWithoutField))
+	field := make(map[string]string, 1)
+	field["pkg"] = "ayi.app.git"
+	entryWithAllowedPkg := &Entry{Fields: field}
+	assert.True(f.Filter(entryWithAllowedPkg))
+	field["pkg"] = "ayi.app.web"
+	entryWithDisallowedPkg := &Entry{Fields: field}
+	assert.False(f.Filter(entryWithDisallowedPkg))
+
+}

--- a/common/log/formatter.go
+++ b/common/log/formatter.go
@@ -1,0 +1,23 @@
+package log
+
+import (
+	"bytes"
+	"fmt"
+)
+
+type Formatter interface {
+	Format(*Entry) ([]byte, error)
+}
+
+type TextFormatter struct {
+}
+
+func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
+	var b *bytes.Buffer
+	// TODO: may use a pool
+	b = &bytes.Buffer{}
+	// TODO: print time
+	// TODO: print fields
+	fmt.Fprintf(b, "[%s]%s\n", entry.Level.String(), entry.Message)
+	return b.Bytes(), nil
+}

--- a/common/log/formatter.go
+++ b/common/log/formatter.go
@@ -3,21 +3,74 @@ package log
 import (
 	"bytes"
 	"fmt"
+	"time"
 )
 
 type Formatter interface {
 	Format(*Entry) ([]byte, error)
 }
 
+var (
+	baseTimeStamp = time.Now()
+)
+
+const (
+	nocolor = 0
+	red     = 31
+	green   = 32
+	yellow  = 33
+	blue    = 34
+	gray    = 37
+)
+
 type TextFormatter struct {
+	EnableColor       bool
+	EnableTimeStamp   bool
+	EnableElapsedTime bool
+	TimeStampFormat   string
+}
+
+func NewTextFormatter() *TextFormatter {
+	return &TextFormatter{
+		EnableColor:       false,
+		EnableTimeStamp:   true,
+		EnableElapsedTime: true,
+		TimeStampFormat:   time.RFC3339,
+	}
 }
 
 func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	var b *bytes.Buffer
 	// TODO: may use a pool
 	b = &bytes.Buffer{}
-	// TODO: print time
-	fmt.Fprintf(b, "[%s]%s ", entry.Level.String(), entry.Message)
+	var levelColor = nocolor
+	if f.EnableColor {
+		switch entry.Level {
+		case InfoLevel:
+			levelColor = blue
+		case WarnLevel:
+			levelColor = yellow
+		case ErrorLevel, FatalLevel, PanicLevel:
+			levelColor = red
+		}
+	}
+	if levelColor != nocolor {
+		fmt.Fprintf(b, "\x1b[%dm%s\x1b[0m", levelColor, entry.Level.ShortUpperString())
+	} else {
+		b.WriteString(entry.Level.ShortUpperString())
+	}
+	if f.EnableTimeStamp {
+		if f.EnableElapsedTime {
+			// NOTE: the elapsedTime copied from logrus is wrong
+			fmt.Fprintf(b, "[%04d]", int(entry.Time.Sub(baseTimeStamp)/time.Second))
+		} else {
+			// TODO: what if the user set TimeStampFormat to an invalid format
+			fmt.Fprintf(b, "[%s]", entry.Time.Format(f.TimeStampFormat))
+		}
+	}
+	b.WriteByte(' ')
+	b.WriteString(entry.Message)
+	b.WriteByte(' ')
 	for k, v := range entry.Fields {
 		b.WriteString(k)
 		b.WriteByte('=')
@@ -26,4 +79,9 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	}
 	b.WriteByte('\n')
 	return b.Bytes(), nil
+}
+
+// NOTE: the elapsedTime copied from logrus is wrong
+func elapsedTime() int {
+	return int(time.Since(baseTimeStamp) / time.Second)
 }

--- a/common/log/formatter.go
+++ b/common/log/formatter.go
@@ -17,7 +17,13 @@ func (f *TextFormatter) Format(entry *Entry) ([]byte, error) {
 	// TODO: may use a pool
 	b = &bytes.Buffer{}
 	// TODO: print time
-	// TODO: print fields
-	fmt.Fprintf(b, "[%s]%s\n", entry.Level.String(), entry.Message)
+	fmt.Fprintf(b, "[%s]%s ", entry.Level.String(), entry.Message)
+	for k, v := range entry.Fields {
+		b.WriteString(k)
+		b.WriteByte('=')
+		b.WriteString(v)
+		b.WriteByte(' ')
+	}
+	b.WriteByte('\n')
 	return b.Bytes(), nil
 }

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -34,6 +34,8 @@ func (level Level) String() string {
 		return "fatal"
 	case ErrorLevel:
 		return "error"
+	case WarnLevel:
+		return "warn"
 	case InfoLevel:
 		return "info"
 	case DebugLevel:
@@ -52,6 +54,7 @@ var AllLevels = []Level{
 	WarnLevel,
 	InfoLevel,
 	DebugLevel,
+	TraceLevel,
 }
 
 // Fields is key-value string pair to annotate the log and can be used by filter
@@ -88,5 +91,6 @@ func (log *Logger) NewEntry() *Entry {
 	// TODO: may use pool
 	return &Entry{
 		Logger: log,
+		Fields: make(map[string]string, 1),
 	}
 }

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -10,10 +10,10 @@ import (
 type Level uint8
 
 const (
-	// PanicLevel log error and call painc
-	PanicLevel Level = iota
 	// FatalLevel log error and call `os.Exit(1)`
-	FatalLevel
+	FatalLevel Level = iota
+	// PanicLevel log error and call painc
+	PanicLevel
 	// ErrorLevel log error
 	ErrorLevel
 	// WarnLevel log warning
@@ -28,10 +28,10 @@ const (
 
 func (level Level) String() string {
 	switch level {
-	case PanicLevel:
-		return "painc"
 	case FatalLevel:
 		return "fatal"
+	case PanicLevel:
+		return "painc"
 	case ErrorLevel:
 		return "error"
 	case WarnLevel:
@@ -48,8 +48,8 @@ func (level Level) String() string {
 }
 
 var AllLevels = []Level{
-	PanicLevel,
 	FatalLevel,
+	PanicLevel,
 	ErrorLevel,
 	WarnLevel,
 	InfoLevel,

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -12,7 +12,7 @@ type Level uint8
 const (
 	// FatalLevel log error and call `os.Exit(1)`
 	FatalLevel Level = iota
-	// PanicLevel log error and call painc
+	// PanicLevel log error and call panic
 	PanicLevel
 	// ErrorLevel log error
 	ErrorLevel
@@ -32,7 +32,7 @@ func (level Level) ShortUpperString() string {
 	case FatalLevel:
 		return "FATA"
 	case PanicLevel:
-		return "PAIN"
+		return "PANI"
 	case ErrorLevel:
 		return "ERRO"
 	case WarnLevel:

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -26,22 +26,67 @@ const (
 	TraceLevel
 )
 
+func (level Level) String() string {
+	switch level {
+	case PanicLevel:
+		return "painc"
+	case FatalLevel:
+		return "fatal"
+	case ErrorLevel:
+		return "error"
+	case InfoLevel:
+		return "info"
+	case DebugLevel:
+		return "debug"
+	case TraceLevel:
+		return "trace"
+	default:
+		return "unknown"
+	}
+}
+
+var AllLevels = []Level{
+	PanicLevel,
+	FatalLevel,
+	ErrorLevel,
+	WarnLevel,
+	InfoLevel,
+	DebugLevel,
+}
+
 // Fields is key-value string pair to annotate the log and can be used by filter
 type Fields map[string]string
 
 type Logger struct {
-	Out   io.Writer
-	Level Level
-	mu    sync.Mutex
+	Out       io.Writer
+	Formatter Formatter
+	Level     Level
+	mu        sync.Mutex
+	Filters   map[Level]map[string]Filter
 }
 
 // NewLogger returns a new logger using StdOut and InfoLevel
 func NewLogger() *Logger {
-	return &Logger{
-		Out:   os.Stdout,
-		Level: InfoLevel,
+	f := make(map[Level]map[string]Filter, len(AllLevels))
+	for _, level := range AllLevels {
+		f[level] = make(map[string]Filter, 1)
 	}
+	l := &Logger{
+		Out:       os.Stdout,
+		Formatter: &TextFormatter{},
+		Level:     InfoLevel,
+		Filters:   f,
+	}
+	return l
 }
 
 func (log *Logger) AddFilter(filter Filter, level Level) {
+	log.Filters[level][filter.Name()] = filter
+}
+
+func (log *Logger) NewEntry() *Entry {
+	// TODO: may use pool
+	return &Entry{
+		Logger: log,
+	}
 }

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -69,6 +69,7 @@ func (level Level) String() string {
 	}
 }
 
+// AllLevels includes all the logging level
 var AllLevels = []Level{
 	FatalLevel,
 	PanicLevel,
@@ -82,6 +83,7 @@ var AllLevels = []Level{
 // Fields is key-value string pair to annotate the log and can be used by filter
 type Fields map[string]string
 
+// Logger is used to set output, formatter and filters, the real log is using Entry
 type Logger struct {
 	Out       io.Writer
 	Formatter Formatter
@@ -105,14 +107,26 @@ func NewLogger() *Logger {
 	return l
 }
 
+// AddFilter add a filter to logger, the filter should be simple string check on fields, i.e. PkgFilter check pkg field
 func (log *Logger) AddFilter(filter Filter, level Level) {
 	log.Filters[level][filter.Name()] = filter
 }
 
+// NewEntry returns an Entry with empty Fields
 func (log *Logger) NewEntry() *Entry {
 	// TODO: may use pool
 	return &Entry{
 		Logger: log,
 		Fields: make(map[string]string, 1),
+	}
+}
+
+// NewEntryWithPkg returns an Entry with pkg Field set to pkgName, should be used with PkgFilter
+func (log *Logger) NewEntryWithPkg(pkgName string) *Entry {
+	fields := make(map[string]string, 1)
+	fields["pkg"] = pkgName
+	return &Entry{
+		Logger: log,
+		Fields: fields,
 	}
 }

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -26,6 +26,28 @@ const (
 	TraceLevel
 )
 
+// ShortUpperString returns the first 4 characters of a level in upper case
+func (level Level) ShortUpperString() string {
+	switch level {
+	case FatalLevel:
+		return "FATA"
+	case PanicLevel:
+		return "PAIN"
+	case ErrorLevel:
+		return "ERRO"
+	case WarnLevel:
+		return "WARN"
+	case InfoLevel:
+		return "INFO"
+	case DebugLevel:
+		return "DEBU"
+	case TraceLevel:
+		return "TRAC"
+	default:
+		return "UNKN"
+	}
+}
+
 func (level Level) String() string {
 	switch level {
 	case FatalLevel:
@@ -76,7 +98,7 @@ func NewLogger() *Logger {
 	}
 	l := &Logger{
 		Out:       os.Stdout,
-		Formatter: &TextFormatter{},
+		Formatter: NewTextFormatter(),
 		Level:     InfoLevel,
 		Filters:   f,
 	}

--- a/common/log/logger.go
+++ b/common/log/logger.go
@@ -1,0 +1,47 @@
+package log
+
+import (
+	"io"
+	"os"
+	"sync"
+)
+
+// Level is log level
+type Level uint8
+
+const (
+	// PanicLevel log error and call painc
+	PanicLevel Level = iota
+	// FatalLevel log error and call `os.Exit(1)`
+	FatalLevel
+	// ErrorLevel log error
+	ErrorLevel
+	// WarnLevel log warning
+	WarnLevel
+	// InfoLevel log info
+	InfoLevel
+	// DebugLevel log debug message, user should enable DebugLevel logging when report bug
+	DebugLevel
+	// TraceLevel is used by developer only, user should stop at DebugLevel if they just want to report
+	TraceLevel
+)
+
+// Fields is key-value string pair to annotate the log and can be used by filter
+type Fields map[string]string
+
+type Logger struct {
+	Out   io.Writer
+	Level Level
+	mu    sync.Mutex
+}
+
+// NewLogger returns a new logger using StdOut and InfoLevel
+func NewLogger() *Logger {
+	return &Logger{
+		Out:   os.Stdout,
+		Level: InfoLevel,
+	}
+}
+
+func (log *Logger) AddFilter(filter Filter, level Level) {
+}

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -6,11 +6,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestAddFilter(t *testing.T) {
+func TestLogger_AddFilter(t *testing.T) {
 	assert := assert.New(t)
 	logger := NewLogger()
 	allow := make(map[string]bool)
 	pkgFilter := NewPkgFilter(allow)
 	logger.AddFilter(pkgFilter, DebugLevel)
 	assert.Equal(1, len(logger.Filters[DebugLevel]))
+}
+
+func TestLogger_NewEntryWithPkg(t *testing.T) {
+	assert := assert.New(t)
+	logger := NewLogger()
+	entry := logger.NewEntryWithPkg("x.dummy")
+	assert.Equal(1, len(entry.Fields))
 }

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -20,4 +20,5 @@ func TestLogger_NewEntryWithPkg(t *testing.T) {
 	logger := NewLogger()
 	entry := logger.NewEntryWithPkg("x.dummy")
 	assert.Equal(1, len(entry.Fields))
+	entry.Info("show me the pkg")
 }

--- a/common/log/logger_test.go
+++ b/common/log/logger_test.go
@@ -1,0 +1,16 @@
+package log
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAddFilter(t *testing.T) {
+	assert := assert.New(t)
+	logger := NewLogger()
+	allow := make(map[string]bool)
+	pkgFilter := NewPkgFilter(allow)
+	logger.AddFilter(pkgFilter, DebugLevel)
+	assert.Equal(1, len(logger.Filters[DebugLevel]))
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,10 @@
-hash: 8efbec41be838b26ab031b466d75232760e685e834194670f1b0595198f50c50
-updated: 2016-08-14T14:16:04.6623922+08:00
+hash: 4fbb76fcfa018bd9d93cdcb00547a9d1f7fa856e38cdec1eda6d93302b889ef0
+updated: 2016-12-17T23:20:18.698835479-08:00
 imports:
 - name: github.com/BurntSushi/toml
   version: f0aeabca5a127c4078abb8c8d64298b147264b55
+- name: github.com/daaku/go.zipexe
+  version: a5fe2436ffcb3236e175e5149162b41cd28bd27d
 - name: github.com/fatih/color
   version: 87d4004f2ab62d0d255e0a38f1680aa534549fe3
   vcs: git
@@ -21,14 +23,16 @@ imports:
   subpackages:
   - hcl/ast
   - hcl/parser
-  - hcl/token
-  - json/parser
   - hcl/scanner
   - hcl/strconv
+  - hcl/token
+  - json/parser
   - json/scanner
   - json/token
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
+- name: github.com/kardianos/osext
+  version: c2c54e542fb797ad986b31721e1baedf214ca413
 - name: github.com/kballard/go-shellquote
   version: d8ec1a69a250a17bb0e419c386eac1f3711dc142
   vcs: git
@@ -47,9 +51,6 @@ imports:
   vcs: git
 - name: github.com/pkg/sftp
   version: a71e8f580e3b622ebff585309160b1cc549ef4d2
-- name: github.com/Sirupsen/logrus
-  version: 4b6ea7319e214d98c938f12692336f7ca9348d6b
-  vcs: git
 - name: github.com/spf13/afero
   version: cc9c21814bb945440253108c4d3c65c85aac3c68
   subpackages:
@@ -67,20 +68,13 @@ imports:
 - name: github.com/spf13/viper
   version: 346299ea79e446ebdddb834371ceba2e5926b732
   vcs: git
-- name: github.com/stretchr/testify
-  version: d77da356e56a7428ad25149ca77381849a6a5232
-  vcs: git
-  subpackages:
-  - assert
-  - suite
-  - require
 - name: golang.org/x/crypto
   version: a548aac93ed489257b9d959b40fe1e8c1e20778c
   subpackages:
-  - ssh
   - curve25519
   - ed25519
   - ed25519/internal/edwards25519
+  - ssh
 - name: golang.org/x/sys
   version: a408501be4d17ee978c04a618e7a1b22af058c0e
   subpackages:
@@ -93,15 +87,18 @@ imports:
 - name: gopkg.in/yaml.v2
   version: a83829b6f1293c91addabc89d0571c246397bbf4
 testImports:
-- name: github.com/daaku/go.zipexe
-  version: a5fe2436ffcb3236e175e5149162b41cd28bd27d
 - name: github.com/davecgh/go-spew
-  version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
+  version: 04cdfd42973bb9c8589fd6a731800cf222fde1a9
   subpackages:
   - spew
-- name: github.com/kardianos/osext
-  version: c2c54e542fb797ad986b31721e1baedf214ca413
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
   - difflib
+- name: github.com/stretchr/testify
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983
+  vcs: git
+  subpackages:
+  - assert
+  - require
+  - suite

--- a/glide.yaml
+++ b/glide.yaml
@@ -12,22 +12,17 @@ import:
 - package: github.com/fatih/color
   vcs: git
   version: 87d4004f2ab62d0d255e0a38f1680aa534549fe3
-- package: github.com/stretchr/testify
-  vcs: git
-  version: d77da356e56a7428ad25149ca77381849a6a5232
 - package: github.com/kballard/go-shellquote
   vcs: git
   version: d8ec1a69a250a17bb0e419c386eac1f3711dc142
-- package: github.com/Sirupsen/logrus
-  vcs: git
-  version: 0.10.0
 # https://github.com/dyweb/Ayi/issues/15 After a long struggle, I chose gocraft
 - package: github.com/gocraft/web
   vcs: git
   version: c8ca29bc8a1cec97abe95c662e29dd8d31aff6e3
-# - package: github.com/jteeuwen/go-bindata
-#   vcs： git
-#   version: a0ff2567cfb70903282db057e799fd826784d41d
 - package: github.com/GeertJohan/go.rice
   vcs: git
   version: 9fdfd46f9806a9228aae341d65ab75c5235c383c
+testImport:
+- package: github.com/stretchr/testify
+  vcs: git
+  version: 2402e8e7a02fc811447d11f881aa9746cdc57983

--- a/util/log.go
+++ b/util/log.go
@@ -1,20 +1,24 @@
 package util
 
 import (
-	"github.com/Sirupsen/logrus"
+	dlog "github.com/dyweb/Ayi/common/log"
 )
 
 // Logger is the default logger with info level
-var Logger = logrus.New()
+var Logger = dlog.NewLogger()
+
 // Short name use in util package
-var log = Logger
+var log = Logger.NewEntryWithPkg("a.util")
 
 func init() {
-	Logger.Formatter = &logrus.TextFormatter{ForceColors: true}
-	Logger.Level = logrus.InfoLevel
+	f := dlog.NewTextFormatter()
+	f.EnableColor = true
+	Logger.Formatter = f
+	Logger.Level = dlog.InfoLevel
 }
 
 // UseVerboseLog set logger level to debug
 func UseVerboseLog() {
-	Logger.Level = logrus.DebugLevel
+	Logger.Level = dlog.DebugLevel
+	log.Debug("enable debug logging")
 }

--- a/util/runner/runner.go
+++ b/util/runner/runner.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var log = util.Logger
+var log = util.Logger.NewEntryWithPkg("a.u.runner")
 
 // https://github.com/dyweb/Ayi/issues/53
 // Command runner behave like nodejs's command runner, execute command in config file

--- a/util/runner/runner.go
+++ b/util/runner/runner.go
@@ -75,7 +75,7 @@ func ExecuteCommand(cmdName string) (int, error) {
 	}
 	success := 0
 	for _, cmd := range commands {
-		log.Infof("executing: %s \n", cmd)
+		log.Infof("executing: %s ", cmd)
 		err := util.RunCommand(cmd)
 
 		if err != nil {

--- a/util/viper.go
+++ b/util/viper.go
@@ -21,16 +21,16 @@ func ViperReadAndMerge(path string) {
 	// TODO: handle other path problems
 	path = filepath.FromSlash(path)
 	if !FileExists(path) {
-		log.WithField("file", path).Debug("Config file NOT found")
+		log.Debugf("Config file NOT found in %s", path)
 		return
 	}
 	viper.SetConfigFile(path)
 	err := viper.MergeInConfig()
 	if err != nil {
-		log.WithField("file", path).Debug("Error merge config: " + err.Error())
+		log.Debugf("Error merge config for %s: %s", path, err.Error())
 		return
 	}
-	log.WithField("file", path).Debug("Config read and merged")
+	log.Debugf("Config read and merged for %s", path)
 }
 
 // copied from viper util since it's a private function


### PR DESCRIPTION
Related #59 

It is basic a clone of logrus with the following modification

- [x] fatal level has lower number than painc level (reversed in logrus)
- [x] remove all the `Debug, Warn` in `Logger`, only keep those methods on `Entry`
- field value can only be string, logrus use `interface{}`
- didn't use lock (though there is a mutex in `Logger`)
- does not support hook, only have filter
- does not trim `\n` for `*f` functions
- [x] add syntax sugar to create entry with pkg i.e. `logger.NewEntryWithPkg("x.tsdb.kairosdb")`

the more detail description can be found in README, all the logrus usage are replaced with `common/log`, and since `WithField` is not supported, it is replaced by `*f`....