### PR TITLE
[partial][common] runner

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,15 +42,6 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	var dummyCmd = &cobra.Command{
-		Use:   "dummy",
-		Short: "dummy is foo",
-		Long:  `dummy is foo bar`,
-		Run: func(cmd *cobra.Command, args []string) {
-			log.Info("Hi I am dummy")
-		},
-	}
-	RootCmd.AddCommand(dummyCmd)
 	if err := RootCmd.Execute(); err != nil {
 		// TODO: use logger
 		// https://github.com/spf13/cobra/issues/304
@@ -87,17 +78,6 @@ func init() {
 
 	// https://github.com/spf13/viper#working-with-flags
 	bindRootCmdFlagsToViper()
-
-	// NOTE: code here does work, but the problem is, you can't get flag?
-	// var dummyCmd = &cobra.Command{
-	// 	Use:   "dummy",
-	// 	Short: "dummy is foo",
-	// 	Long:  `dummy is foo bar`,
-	// 	Run: func(cmd *cobra.Command, args []string) {
-	// 		log.Info("Hi I am dummy")
-	// 	},
-	// }
-	// RootCmd.AddCommand(dummyCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -117,16 +97,4 @@ func initConfig() {
 
 	// Set default value for viper
 	loadDefaultSettings()
-
-	// FIXME: this is just test if dynamic registering command is possible for cobra
-	// TODO: code does not work here
-	// var dummyCmd = &cobra.Command{
-	// 	Use:   "dummy",
-	// 	Short: "dummy is foo",
-	// 	Long:  `dummy is foo bar`,
-	// 	Run: func(cmd *cobra.Command, args []string) {
-	// 		log.Info("Hi I am dummy")
-	// 	},
-	// }
-	// RootCmd.AddCommand(dummyCmd)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,15 @@ var RootCmd = &cobra.Command{
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
+	var dummyCmd = &cobra.Command{
+		Use:   "dummy",
+		Short: "dummy is foo",
+		Long:  `dummy is foo bar`,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Info("Hi I am dummy")
+		},
+	}
+	RootCmd.AddCommand(dummyCmd)
 	if err := RootCmd.Execute(); err != nil {
 		// TODO: use logger
 		// https://github.com/spf13/cobra/issues/304
@@ -80,15 +89,15 @@ func init() {
 	bindRootCmdFlagsToViper()
 
 	// NOTE: code here does work, but the problem is, you can't get flag?
-	var dummyCmd = &cobra.Command{
-		Use:   "dummy",
-		Short: "dummy is foo",
-		Long:  `dummy is foo bar`,
-		Run: func(cmd *cobra.Command, args []string) {
-			log.Info("Hi I am dummy")
-		},
-	}
-	RootCmd.AddCommand(dummyCmd)
+	// var dummyCmd = &cobra.Command{
+	// 	Use:   "dummy",
+	// 	Short: "dummy is foo",
+	// 	Long:  `dummy is foo bar`,
+	// 	Run: func(cmd *cobra.Command, args []string) {
+	// 		log.Info("Hi I am dummy")
+	// 	},
+	// }
+	// RootCmd.AddCommand(dummyCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,17 @@ func init() {
 
 	// https://github.com/spf13/viper#working-with-flags
 	bindRootCmdFlagsToViper()
+
+	// NOTE: code here does work, but the problem is, you can't get flag?
+	var dummyCmd = &cobra.Command{
+		Use:   "dummy",
+		Short: "dummy is foo",
+		Long:  `dummy is foo bar`,
+		Run: func(cmd *cobra.Command, args []string) {
+			log.Info("Hi I am dummy")
+		},
+	}
+	RootCmd.AddCommand(dummyCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -97,4 +108,16 @@ func initConfig() {
 
 	// Set default value for viper
 	loadDefaultSettings()
+
+	// FIXME: this is just test if dynamic registering command is possible for cobra
+	// TODO: code does not work here
+	// var dummyCmd = &cobra.Command{
+	// 	Use:   "dummy",
+	// 	Short: "dummy is foo",
+	// 	Long:  `dummy is foo bar`,
+	// 	Run: func(cmd *cobra.Command, args []string) {
+	// 		log.Info("Hi I am dummy")
+	// 	},
+	// }
+	// RootCmd.AddCommand(dummyCmd)
 }

--- a/common/README.md
+++ b/common/README.md
@@ -2,17 +2,24 @@
 
 Common utils that could be used outside Ayi
 
-- log
-- command runner
+- [data structure](structure) 
+- [log](log)
+- [command runner](runner)
 - web server
 - http client 
 - resource binding (replace go.rice) 
+
+## Data structure
+
+see [data structure](structure)
+
+- Set
 
 ## Log
 
 see [log](log)
 
-- filter log by fields
+- filter log by fields, built in support for pkg using `PkgFilter`
 
 ## Command runner
 

--- a/common/README.md
+++ b/common/README.md
@@ -10,9 +10,13 @@ Common utils that could be used outside Ayi
 
 ## Log
 
+see [log](log)
+
 - filter log by fields
 
 ## Command runner
+
+see [runner](runner)
 
 - dry run
 - run in background (like foreman)
@@ -20,7 +24,7 @@ Common utils that could be used outside Ayi
 
 ## Web server
 
-- static file server (`Ayi web static`)
+- static file server (`Ayi web static`) like python's `SimpleHTTPServer`
 
 ## Http client
 

--- a/common/log/filter.go
+++ b/common/log/filter.go
@@ -1,6 +1,8 @@
 package log
 
-type Set map[string]bool
+import (
+	st "github.com/dyweb/Ayi/common/structure"
+)
 
 // Filter determines if the entry should be logged
 type Filter interface {
@@ -10,7 +12,7 @@ type Filter interface {
 
 // PkgFilter only allows entry without `pkg` field or `pkg` value in the allow set to pass
 type PkgFilter struct {
-	allow Set
+	allow st.Set
 }
 
 func (filter *PkgFilter) Filter(entry *Entry) bool {
@@ -19,16 +21,14 @@ func (filter *PkgFilter) Filter(entry *Entry) bool {
 	if !ok {
 		return true
 	}
-	// TODO: may store bool to enable disallow using just one map.
-	_, ok = filter.allow[pkg]
-	return ok
+	return filter.allow.Contains(pkg)
 }
 
 func (filter *PkgFilter) Name() string {
 	return "PkgFilter"
 }
 
-func NewPkgFilter(allow Set) *PkgFilter {
+func NewPkgFilter(allow st.Set) *PkgFilter {
 	return &PkgFilter{
 		allow: allow,
 	}

--- a/common/runner/command.go
+++ b/common/runner/command.go
@@ -1,0 +1,17 @@
+package runner
+
+import (
+	"os/exec"
+
+	"github.com/kballard/go-shellquote"
+	"github.com/pkg/errors"
+)
+
+// NewCmd can properly split the executable with its arguments
+func NewCmd(cmdStr string) (*exec.Cmd, error) {
+	segments, err := shellquote.Split(cmdStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't parse command")
+	}
+	return exec.Command(segments[0], segments[1:]...), nil
+}

--- a/common/runner/command.go
+++ b/common/runner/command.go
@@ -11,7 +11,7 @@ import (
 
 // commands that should be called using shell,
 // because mostly they would be expecting shell expansion on parameters
-var shellCommands = st.NewSet("rm", "cp", "mv", "mkdir", "tar")
+var shellCommands = st.NewSet("echo", "rm", "cp", "mv", "mkdir", "tar")
 
 // NewCmd can properly split the executable with its arguments
 // TODO: may need to add a context to handle things like using shell or not

--- a/common/runner/command.go
+++ b/common/runner/command.go
@@ -1,11 +1,20 @@
 package runner
 
 import (
+	"os"
 	"os/exec"
 
 	"github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
 )
+
+// commands that should be called using shell,
+// because mostly they would be expecting shell expansion on parameters
+// FIXME: use a map as set
+var shellCommands = []string{
+	"rm", "cp", "mv", "mkdir",
+	"tar",
+}
 
 // NewCmd can properly split the executable with its arguments
 // TODO: may need to add a context to handle things like using shell or not
@@ -13,6 +22,31 @@ func NewCmd(cmdStr string) (*exec.Cmd, error) {
 	segments, err := shellquote.Split(cmdStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't parse command")
+	}
+	return exec.Command(segments[0], segments[1:]...), nil
+}
+
+// NewCmdWithAutoShell automatically use `sh -c` syntax for a small list of executable
+// because most people expect shell expansion i.e. wild chars when using them
+// TODO: test
+func NewCmdWithAutoShell(cmdStr string) (*exec.Cmd, error) {
+	segments, err := shellquote.Split(cmdStr)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't parse command")
+	}
+	name := segments[0]
+	useShell := false
+	for _, c := range shellCommands {
+		if name == c {
+			useShell = true
+			break
+		}
+	}
+	if useShell {
+		// TODO: may use shellquote join?
+		// NOTE: http://stackoverflow.com/questions/18946837/go-variadic-function-and-too-many-arguments
+		// the `append` here is a must "sh", "-c", segments[1:]... won't work
+		return exec.Command("sh", append([]string{"-c"}, segments[1:]...)...), nil
 	}
 	return exec.Command(segments[0], segments[1:]...), nil
 }

--- a/common/runner/command.go
+++ b/common/runner/command.go
@@ -8,10 +8,27 @@ import (
 )
 
 // NewCmd can properly split the executable with its arguments
+// TODO: may need to add a context to handle things like using shell or not
 func NewCmd(cmdStr string) (*exec.Cmd, error) {
 	segments, err := shellquote.Split(cmdStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't parse command")
 	}
 	return exec.Command(segments[0], segments[1:]...), nil
+}
+
+func RunCommand(cmdStr string) error {
+	cmd, err := NewCmd(cmdStr)
+	if err != nil {
+		return errors.Wrap(err, "can't create cmd from command string")
+	}
+	// TODO: dry run, maybe add a context
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return errors.Wrap(err, "failure when executing command")
+	}
+	return nil
 }

--- a/common/runner/command.go
+++ b/common/runner/command.go
@@ -4,17 +4,14 @@ import (
 	"os"
 	"os/exec"
 
+	st "github.com/dyweb/Ayi/common/structure"
 	"github.com/kballard/go-shellquote"
 	"github.com/pkg/errors"
 )
 
 // commands that should be called using shell,
 // because mostly they would be expecting shell expansion on parameters
-// FIXME: use a map as set
-var shellCommands = []string{
-	"rm", "cp", "mv", "mkdir",
-	"tar",
-}
+var shellCommands = st.NewSet("rm", "cp", "mv", "mkdir", "tar")
 
 // NewCmd can properly split the executable with its arguments
 // TODO: may need to add a context to handle things like using shell or not
@@ -28,20 +25,14 @@ func NewCmd(cmdStr string) (*exec.Cmd, error) {
 
 // NewCmdWithAutoShell automatically use `sh -c` syntax for a small list of executable
 // because most people expect shell expansion i.e. wild chars when using them
-// TODO: test
+// TODO: test if it really works, current unit test just test the number of arguments
 func NewCmdWithAutoShell(cmdStr string) (*exec.Cmd, error) {
 	segments, err := shellquote.Split(cmdStr)
 	if err != nil {
 		return nil, errors.Wrap(err, "can't parse command")
 	}
 	name := segments[0]
-	useShell := false
-	for _, c := range shellCommands {
-		if name == c {
-			useShell = true
-			break
-		}
-	}
+	useShell := shellCommands.Contains(name)
 	if useShell {
 		// TODO: may use shellquote join?
 		// NOTE: http://stackoverflow.com/questions/18946837/go-variadic-function-and-too-many-arguments

--- a/common/runner/command_test.go
+++ b/common/runner/command_test.go
@@ -22,4 +22,5 @@ func TestNewCmdWithAutoShell(t *testing.T) {
 	assert.Equal(3, len(cmd.Args))
 	// TODO: why this is not /bin/sh
 	assert.Equal("sh", cmd.Args[0])
+	assert.Equal("-c", cmd.Args[1])
 }

--- a/common/runner/command_test.go
+++ b/common/runner/command_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 // https://github.com/dyweb/Ayi/issues/58
+// NOTE: it's not extra quote, it's os/exec can't expand * like shell does
+// when run `rm *.aux` in shell, shell expands `*.aux` to real file names
 func TestNewCommand_ExtraQuote(t *testing.T) {
 	assert := assert.New(t)
 	cmd, _ := NewCmd("rm *.aux")
 	assert.Equal(2, len(cmd.Args))
-	// assert.Equal("/bin/rm", cmd.Path)
 	assert.Equal("*.aux", cmd.Args[1])
-	// TODO: it seems shell quote is right
 }

--- a/common/runner/command_test.go
+++ b/common/runner/command_test.go
@@ -15,3 +15,11 @@ func TestNewCommand_ExtraQuote(t *testing.T) {
 	assert.Equal(2, len(cmd.Args))
 	assert.Equal("*.aux", cmd.Args[1])
 }
+
+func TestNewCmdWithAutoShell(t *testing.T) {
+	assert := assert.New(t)
+	cmd, _ := NewCmdWithAutoShell("rm *.aux")
+	assert.Equal(3, len(cmd.Args))
+	// TODO: why this is not /bin/sh
+	assert.Equal("sh", cmd.Args[0])
+}

--- a/common/runner/command_test.go
+++ b/common/runner/command_test.go
@@ -1,0 +1,17 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// https://github.com/dyweb/Ayi/issues/58
+func TestNewCommand_ExtraQuote(t *testing.T) {
+	assert := assert.New(t)
+	cmd, _ := NewCmd("rm *.aux")
+	assert.Equal(2, len(cmd.Args))
+	// assert.Equal("/bin/rm", cmd.Path)
+	assert.Equal("*.aux", cmd.Args[1])
+	// TODO: it seems shell quote is right
+}

--- a/common/runner/context.go
+++ b/common/runner/context.go
@@ -1,0 +1,22 @@
+package runner
+
+// Context describes how the command should be run
+// i.e. use shell instead of using os/exec,
+// use self defined logic instead of lookup an exectuable
+// run in background
+type Context struct {
+	AutoShell  bool
+	Foreground bool
+	Block      bool
+	Dry        bool
+}
+
+// NewContext returns a context with convention
+func NewContext() *Context {
+	return &Context{
+		AutoShell:  true,
+		Foreground: true,
+		Block:      true,
+		Dry:        false,
+	}
+}

--- a/common/runner/doc.go
+++ b/common/runner/doc.go
@@ -1,4 +1,4 @@
 /*
-Package runner run commands
+Package runner run commands with some convention
 */
 package runner

--- a/common/runner/doc.go
+++ b/common/runner/doc.go
@@ -1,0 +1,4 @@
+/*
+Package runner run commands
+*/
+package runner

--- a/common/runner/example.config.yml
+++ b/common/runner/example.config.yml
@@ -1,0 +1,47 @@
+# an example of the new runner package config
+
+# global config for the runner 
+scripts-config:
+    # disable autoshell, no longer check for command like rm, mv and switch to sh -c for them
+    autoshell: false
+
+# definition of scripts
+scripts:
+    # call gofmt using os/exec 
+    fmt: gofmt .
+    # will be translated to sh -c "rm *.obj" if autoshell is enabled in global config
+    clean: rm *.obj
+    # a command with detail context
+    clean-plus:
+        cmd: rm *.obj
+        # force using sh -c regardless of global autoshell config
+        shell: true
+        # allow this command to have error and continue other commands, rm will exit when no file is found
+        fallible: true
+    test:
+        # use array to execute a list of commands one by one
+        - go install
+        # you can also use sh -c for force using shell, no extra sh -c will be added around it
+        - sh -c "go test -v -cover $(glide novendor)"
+    build:
+        # call the test command we previously defined
+        - test
+        - go install
+        - gox -output="build/Ayi_{{.OS}}_{{.Arch}}"
+        # you can mix object into the array and use the attributes you use for a top command
+        - cmd: rm *.obj
+          shell: true
+          fallible: true
+    serve:
+        - cmd: Ayi web static
+          desc: serve static web content
+          # run in background, all the background commands are run in parrallel, since they won't end in a short time
+          background: true
+          # restart if the running process exit
+          restart: true
+          # TODO: maybe we should not support the number, need to have counter for cmd syntax
+          number: 1
+        - cmd: Ayi web notify
+          desc: serve notification and display in browser page
+          background: true
+          restart: true

--- a/common/structure/set.go
+++ b/common/structure/set.go
@@ -1,0 +1,21 @@
+package structure
+
+// Set is a map with string key and bool value
+// It is not thread safe and modeled after https://github.com/deckarep/golang-set/blob/master/threadunsafe.go
+type Set map[string]bool
+
+// NewSet return a pointer of a set using arguments passed to the function
+func NewSet(args ...string) *Set {
+	// TODO: would this length for the map?
+	m := make(Set, len(args))
+	for _, v := range args {
+		m[v] = true
+	}
+	return &m
+}
+
+// Contains check if a key is presented in the map, it does NOT check the bool value
+func (set *Set) Contains(key string) bool {
+	_, ok := (*set)[key]
+	return ok
+}

--- a/common/structure/set.go
+++ b/common/structure/set.go
@@ -19,3 +19,7 @@ func (set *Set) Contains(key string) bool {
 	_, ok := (*set)[key]
 	return ok
 }
+
+func (set *Set) Add(key string) {
+	(*set)[key] = true
+}

--- a/common/structure/set_test.go
+++ b/common/structure/set_test.go
@@ -1,0 +1,14 @@
+package structure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSet_Contains(t *testing.T) {
+	assert := assert.New(t)
+	s := NewSet("a", "b", "c")
+	assert.True(s.Contains("a"))
+	assert.False(s.Contains("d"))
+}


### PR DESCRIPTION
Related #63, #65 

This should not only make runner more general but also solve some old problems like #56 #58 . 
Currently the focus is on 

- [ ] more expressive config file
- [ ] allow running process in background, act like a process manager, (Ayi itself should also be able to run like a daemon, may provide some api for short life Ayi instance to communicate with it?)
- [ ] abstract the config parsing, make viper one of the adapter, not bound with it